### PR TITLE
Adding module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ The Puppetconf.yaml file into the puppet-master directory, gives you all the con
  * `shared_hiera`: This is a boolean to define wether you want to share a local/custom hiera directory or use the default configured from a repo
  * `shared_hiera_path`: In case `shared_hiera` is true, this variable is used to indicate the path to the hiera value you want to share into the puppet-master server.
 
+The provisioning script now allows the usage of arguments for the script:
+
+    -S: Indicates wether you want to share a hiera or not"
+    -p: Puppet environment to be used"
+    -i: IP assigned to this puppet master, added in the /etc/hosts"
+    -m: Name of the module to be mounted"
+    -M: Puppet environment in where this module will be mounted"
+
+Tests done already by deploying the puppet master and the headerservice mounting the code from the outside.
+
+There is a known issue with the puppet master and the VM, which prevent the machine to boot after it has been powered off for the very first time, just to be aware.
+
 **puppet-master**
 
 To start up a Puppet Master, go into puppet-master directory and execute vagrant up. The ip for the puppet master is 10.0.0.250. Hostname configured as puppet-master.dev.lsst.org.

--- a/puppet-master/Puppetconf.yaml
+++ b/puppet-master/Puppetconf.yaml
@@ -17,8 +17,8 @@ puppet-master:
         #gitcode_path: "../../itconf_l1ts/"
         #Location in where this will be mounted will be calculated from the puppet environment as:
         #  * /etc/puppetlabs/code/environment/<module_puppet_environment>/modules/<module_name>
-        module_development:
-                module_name: "headerservice"
-                module_code_orig_path: "../../itconf_l1ts/modules/headerservice/"
-                module_puppet_environment: "production"
+        #module_development:
+        #        module_name: "headerservice"
+        #        module_code_orig_path: "../../itconf_l1ts/modules/headerservice/"
+        #        module_puppet_environment: "production"
  

--- a/puppet-master/Puppetconf.yaml
+++ b/puppet-master/Puppetconf.yaml
@@ -17,7 +17,7 @@ puppet-master:
         #gitcode_path: "../../itconf_l1ts/"
         #Location in where this will be mounted will be calculated from the puppet environment as:
         #  * /etc/puppetlabs/code/environment/<module_puppet_environment>/modules/<module_name>
-        module_development: 
+        module_development:
                 module_name: "headerservice"
                 module_code_orig_path: "../../itconf_l1ts/modules/headerservice/"
                 module_puppet_environment: "production"

--- a/puppet-master/Puppetconf.yaml
+++ b/puppet-master/Puppetconf.yaml
@@ -11,8 +11,14 @@ puppet-master:
         # * hiera_repo
         shared_hiera: false
         shared_hiera_path: "hiera"
-        # gitcode_path will be mounted on this environment in: /etc/puppetlabs/code/environments/$ENVIRONMENT
+        #gitcode_path will be mounted on this environment in: /etc/puppetlabs/code/environments/$ENVIRONMENT
         #puppet_environment: "IT_1101_avillalobos"
         # If you want to work on your own puppet code, we recommend adding this variable with the path in where the puppet code is
-        #gitcode_path: "../../itconf_l1ts/"  
+        #gitcode_path: "../../itconf_l1ts/"
+        #Location in where this will be mounted will be calculated from the puppet environment as:
+        #  * /etc/puppetlabs/code/environment/<module_puppet_environment>/modules/<module_name>
+        module_development: 
+                module_name: "headerservice"
+                module_code_orig_path: "../../itconf_l1ts/modules/headerservice/"
+                module_puppet_environment: "production"
  

--- a/puppet-master/Vagrantfile
+++ b/puppet-master/Vagrantfile
@@ -9,20 +9,27 @@ Vagrant.configure("2") do |config|
 		puppet.vm.box = "centos/7"
 		puppet.vm.hostname = Puppetconf["hostname"]
 		puppet.vm.synced_folder '.', '/vagrant'
+
+		$provisioning_args = "-i #{Puppetconf['ip']}"
+
 		if Puppetconf.key?("gitcode_path")
+		  #This file is mounted here because the final location is decided on the provisioning script depending on different circumstances.
+			#This also prevents r10k overwritting whatever is being shared in the final location.
 			puppet.vm.synced_folder Puppetconf["gitcode_path"], "/opt/puppet-code"
 		end
 
-		$shared_hiera_value = "false"
 		if Puppetconf.key?("shared_hiera") and Puppetconf["shared_hiera"]
 			puppet.vm.synced_folder Puppetconf["shared_hiera_path"], "/etc/puppetlabs/code/hieradata/production"
-			$shared_hiera_value = "true"
+			$provisioning_args = $provisioning_args + " -S"
 		end
-		if Puppetconf.key?("puppet_environment")
-			puppet.vm.provision :shell, :path => 'provision-script.sh', :args => [Puppetconf["puppet_environment"], Puppetconf["ip"], $shared_hiera_value ]
-		else
-			puppet.vm.provision :shell, :path => 'provision-script.sh', :args => ["production", Puppetconf["ip"], $shared_hiera_value ]
+
+		if Puppetconf.key?("module_development")
+			puppet.vm.synced_folder Puppetconf["module_development"]["module_code_orig_path"], "/opt/#{Puppetconf['module_development']['module_name']}"
+			$provisioning_args = $provisioning_args + " -m #{Puppetconf['module_development']['module_name']} -M #{Puppetconf['module_development']['module_puppet_environment']}"
 		end
+		
+		puppet.vm.provision :shell, :path => 'provision-script.sh', :args => $provisioning_args
+
 		puppet.vm.network "private_network", ip: Puppetconf["ip"]
 		puppet.ssh.forward_x11 = true
 		puppet.vm.provider "virtualbox" do |v|

--- a/puppet-master/provision-script.sh
+++ b/puppet-master/provision-script.sh
@@ -99,7 +99,7 @@ else
     basedir: '/etc/puppetlabs/code/hieradata'
 " > /etc/puppetlabs/r10k/r10k.yaml
 fi
-/opt/puppetlabs/puppet/bin/r10k deploy environment -t
+/opt/puppetlabs/puppet/bin/r10k deploy environment -p
 
 
 if $SHAREDHIERA ;

--- a/puppet-master/provision-script.sh
+++ b/puppet-master/provision-script.sh
@@ -5,6 +5,8 @@ usage() {
 	echo "-S: Indicates wether you want to share a hiera or not"
 	echo "-p: Puppet environment to be used"
 	echo "-i: IP assigned to this puppet master, added in the /etc/hosts"
+	echo "-m: Name of the module to be mounted"
+	echo "-M: Puppet environment in where this module will be mounted"
 }
 ENVIRONMENT=""
 SHAREDHIERA=false

--- a/puppet-master/provision-script.sh
+++ b/puppet-master/provision-script.sh
@@ -51,6 +51,9 @@ echo -e "\n[agent]\nserver = puppet-master.dev.lsst.org" >> /etc/puppetlabs/pupp
 echo -e "${IP}\tpuppet-master\tpuppet-master.dev.lsst.org" > /etc/hosts
 
 sed -i 's#^PATH=.*#PATH=$PATH:/opt/puppetlabs/puppet/bin:$HOME/bin#g' /root/.bash_profile
+
+#TODO HoxFix -> This installation should be removed once bug <https://github.com/puppetlabs/r10k/issues/930> is fixed
+/opt/puppetlabs/puppet/bin/gem install cri:2.15.6
 /opt/puppetlabs/puppet/bin/gem install r10k
 
 if [ ! -d /etc/puppetlabs/r10k/ ]
@@ -94,7 +97,7 @@ else
     basedir: '/etc/puppetlabs/code/hieradata'
 " > /etc/puppetlabs/r10k/r10k.yaml
 fi
-/opt/puppetlabs/puppet/bin/r10k deploy environment -p
+/opt/puppetlabs/puppet/bin/r10k deploy environment -t
 
 
 if $SHAREDHIERA ;

--- a/puppet-master/provision-script.sh
+++ b/puppet-master/provision-script.sh
@@ -1,13 +1,46 @@
 #!/bin/bash
 
-ENVIRONMENT=$1
-IP=$2
-if [ $# -gt 2 ]
-then
-	SHAREDHIERA=$3
-else
-	SHAREDHIERA=false
-fi
+usage() { 
+	echo "Usage:" 
+	echo "-S: Indicates wether you want to share a hiera or not"
+	echo "-p: Puppet environment to be used"
+	echo "-i: IP assigned to this puppet master, added in the /etc/hosts"
+}
+ENVIRONMENT=""
+SHAREDHIERA=false
+MODULE_NAME=""
+MODULE_PUPPET_ENV=""
+IP=""
+while getopts ":Sp:m:M:i:" o; do
+	case "${o}" in
+			S)
+					SHAREDHIERA=true
+					;;
+			p)
+					ENVIRONMENT=${OPTARG}
+					;;
+			m)
+					MODULE_NAME=${OPTARG}
+					;;
+			M)
+					MODULE_PUPPET_ENV=${OPTARG}
+					;;
+			i)
+			    IP=${OPTARG}
+					;;
+			*)
+					usage
+					;;
+	esac
+done
+shift $((OPTIND-1))
+
+echo "Options received:"
+echo -e "\t * Puppet IP: $IP"
+echo -e "\t * Shared Hiera: $SHAREDHIERA"
+echo -e "\t * Puppet Environment: $ENVIRONMENT"
+echo -e "\t * Module Name: $MODULE_NAME"
+echo -e "\t * Module Puppet Environment: $MODULE_PUPPET_ENV"
 
 rpm -Uvh https://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm
 yum install -y puppetserver git
@@ -30,14 +63,13 @@ then
 	mkdir -p /etc/puppetlabs/code/hieradata/production
 fi
 
-if [ -z "$(grep etc_puppetlabs_code_hieradata_production /etc/fstab)" ]
-then
-echo "etc_puppetlabs_code_hieradata_production /etc/puppetlabs/code/hieradata/production vboxsf defaults,ro 0 0" >> /etc/fstab
-	mount -a
-fi
-
 if  $SHAREDHIERA ;
 then 
+	if [ -z "$(grep etc_puppetlabs_code_hieradata_production /etc/fstab)" ]
+	then
+	echo "etc_puppetlabs_code_hieradata_production /etc/puppetlabs/code/hieradata/production vboxsf defaults,ro 0 0" >> /etc/fstab
+		mount -a
+	fi
 	echo -e "---
 :cachedir: '/var/cache/r10k'
 
@@ -109,4 +141,17 @@ systemctl start puppetserver
 
 systemctl restart puppetserver
 
+# This mount is being done at the very end to avoid conflicts with r10k and puppet agent.
 
+# If there is a shared folder for the puppet code
+if [ ! -z "$(VBoxControl sharedfolder list | grep opt_${MODULE_NAME})" ] 
+then
+	# if the sharefolder is not in the fstab yet
+	if [ -z "$(grep opt_${MODULE_NAME} /etc/fstab)" ]
+	then
+		echo "Shared puppet module code dir found, mounted into: /etc/puppetlabs/code/environments/${MODULE_PUPPET_ENV}/modules/${MODULE_NAME}"
+		echo "opt_${MODULE_NAME} /opt/${MODULE_NAME} vboxfs defaults,ro 0 0" >> /etc/fstab
+		echo "/opt/${MODULE_NAME} /etc/puppetlabs/code/environments/${MODULE_PUPPET_ENV}/modules/${MODULE_NAME} none defaults,ro,bind 0 0" >> /etc/fstab
+		mount -a
+	fi
+fi


### PR DESCRIPTION
As per discussion along with @mareuter and @womullan. We needed to have a way of mounting a module's code inside the puppet master VM to quickly edit and work with the puppet code outside the VM in the host machine.

The following changes allows Vagrant and the provisioning script to mount a module inside the puppet master.

Puppetconf.yaml has changed to add the module_development hash, with 3 keys inside, **module_name** (the name that will be used inside the puppet master), **module_code_orig_path** path in the host machine in where the code you will work on is and finally **module_puppet_environment** which is the puppet's environment in where this module will be mounted.

Vagrantfile has changed to use the parameters added to the provisioning script. and also to mount this new module's directory.

This PR only considers the mount of 1 module at the same time. In the future, this can be a list of modules to be mounted inside the puppet-master.

The provisioning script now allows the usage of arguments for the script:

- -S: Indicates wether you want to share a hiera or not"
- -p: Puppet environment to be used"
- -i: IP assigned to this puppet master, added in the /etc/hosts"
- -m: Name of the module to be mounted"
- -M: Puppet environment in where this module will be mounted"

Tests done already by deploying the puppet master and the headerservice mounting the code from the outside.

There is a known issue with the puppet master and the VM, which prevent the machine to boot after it has been powered off for the very first time, just to be aware.